### PR TITLE
Mcan

### DIFF
--- a/samv7/examples/mcan/build/ewarm/mcan.ewp
+++ b/samv7/examples/mcan/build/ewarm/mcan.ewp
@@ -724,7 +724,7 @@
         </option>
         <option>
           <name>IlinkIcfFile</name>
-          <state>$PROJ_DIR$\..\..\..\..\libraries\libboard\resources_v71\iar\samv71q21_sram.icf</state>
+          <state>$PROJ_DIR$\..\..\..\..\libraries\libboard\resources_v71\nocache_region\iar\samv71q21_sram.icf</state>
         </option>
         <option>
           <name>IlinkIcfFileSlave</name>
@@ -1683,7 +1683,7 @@
         </option>
         <option>
           <name>IlinkIcfFile</name>
-          <state>$PROJ_DIR$\..\..\..\..\libraries\libboard\resources_v71\iar\samv71q21_flash.icf</state>
+          <state>$PROJ_DIR$\..\..\..\..\libraries\libboard\resources_v71\nocache_region\iar\samv71q21_flash.icf</state>
         </option>
         <option>
           <name>IlinkIcfFileSlave</name>

--- a/samv7/examples/mcan/main.c
+++ b/samv7/examples/mcan/main.c
@@ -306,16 +306,16 @@ extern int main(void)
 					/* periodically transmit messages while SW0 is not pushed */
 					// send standard ID from a dedicated buffer
 					*txMailbox0 = MSG_ID_0_DATA1;  // write data into CAN mailbox
-					MCAN_SendTxDedBuffer(&mcan1Config, TX_BUFFER_0);  // send data
+					MCAN_SendTxDedBuffer(&mcan1Config, TX_BUFFER_0, CAN_STANDARD);  // send data
 					txdCntr++;
 					// send extended ID from a dedicated buffer
 					*txMailbox1 = MSG_ID_1_DATA1_4;  // write data into CAN mailbox
 					*(txMailbox1 + 1) = MSG_ID_1_DATA5_8; // write data into CAN mailbox
-					MCAN_SendTxDedBuffer(&mcan1Config, TX_BUFFER_1); // send the data
+					MCAN_SendTxDedBuffer(&mcan1Config, TX_BUFFER_1, CAN_STANDARD); // send the data
 					txdCntr++;
 					// send from Tx Queue
 					MCAN_AddToTxFifoQ(&mcan1Config, MSG_ID_2 + id_offset, CAN_STD_ID,
-							CAN_DLC_1, &txData[0]);
+							CAN_DLC_1, &txData[0], CAN_STANDARD);
 					txdCntr++;
 					// increment the offset so we send different ID's within the
 					// range defined by the mask

--- a/samv7/libraries/libchip/include/mcan.h
+++ b/samv7/libraries/libchip/include/mcan.h
@@ -3,6 +3,7 @@
 /*                       SAM Software Package License                           */
 /* ---------------------------------------------------------------------------- */
 /* Copyright (c) 2015, Atmel Corporation                                        */
+/* Copyright (c) 2017, Microchip                                                */
 /*                                                                              */
 /* All rights reserved.                                                         */
 /*                                                                              */
@@ -60,6 +61,9 @@
 extern "C" {
 #endif
 
+#define CAN_11_BIT_ID_MASK                 (0x7FF)
+#define CAN_29_BIT_ID_MASK                 (0x1FFFFFFF)
+  
 typedef enum {
 	CAN_STD_ID = 0,
 	CAN_EXT_ID = 1
@@ -281,12 +285,13 @@ uint8_t   *MCAN_ConfigTxDedBuffer(
 
 void MCAN_SendTxDedBuffer(
 	const MCan_ConfigType *mcanConfig,
-	uint8_t buffer);
+	uint8_t buffer,
+	uint8_t mode);
 
 uint32_t MCAN_AddToTxFifoQ(
 	const MCan_ConfigType *mcanConfig,
 	uint32_t id, MCan_IdType idType,
-	MCan_DlcType dlc, uint8_t *data);
+	MCan_DlcType dlc, uint8_t *data, uint8_t mode);
 
 uint8_t MCAN_IsBufferTxd(
 	const MCan_ConfigType *mcanConfig,
@@ -320,6 +325,10 @@ uint32_t MCAN_GetRxFifoBuffer(
 	const MCan_ConfigType *mcanConfig,
 	MCan_FifoType fifo,
 	Mailbox64Type *pRxMailbox);
+
+void MCAN_ConfigRxFifoFilter(const MCan_ConfigType *mcanConfig,
+	MCan_FifoType fifo, uint8_t filter, uint32_t id,
+	MCan_IdType idType, uint32_t mask);
 
 #ifdef __cplusplus
 }

--- a/samv7/libraries/libchip/include/samv71/component/component_mcan.h
+++ b/samv7/libraries/libchip/include/samv71/component/component_mcan.h
@@ -3,6 +3,7 @@
 /*                       SAM Software Package License                           */
 /* ---------------------------------------------------------------------------- */
 /* Copyright (c) 2015, Atmel Corporation                                        */
+/* Copyright (c) 2017, Microchip                                                */
 /*                                                                              */
 /* All rights reserved.                                                         */
 /*                                                                              */
@@ -38,6 +39,7 @@
 
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 /** \brief Mcan hardware registers */
+#ifdef MRLA
 typedef struct {
   __I  uint32_t MCAN_CREL;    /**< \brief (Mcan Offset: 0x00) Core Release Register */
   __I  uint32_t MCAN_ENDN;    /**< \brief (Mcan Offset: 0x04) Endian Register */
@@ -91,6 +93,62 @@ typedef struct {
   __I  uint32_t MCAN_TXEFS;   /**< \brief (Mcan Offset: 0xF4) Transmit Event FIFO Status Register */
   __IO uint32_t MCAN_TXEFA;   /**< \brief (Mcan Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
 } Mcan;
+#else
+typedef struct {
+  __I  uint32_t MCAN_CREL;    /**< \brief (Mcan Offset: 0x00) Core Release Register */
+  __I  uint32_t MCAN_ENDN;    /**< \brief (Mcan Offset: 0x04) Endian Register */
+  __IO uint32_t MCAN_CUST;    /**< \brief (Mcan Offset: 0x08) Customer Register */
+  __IO uint32_t MCAN_DBTP;    /**< \brief (Mcan Offset: 0x0C) Data Bit Timing & Prescaler Register */
+  __IO uint32_t MCAN_TEST;    /**< \brief (Mcan Offset: 0x10) Test Register */
+  __IO uint32_t MCAN_RWD;     /**< \brief (Mcan Offset: 0x14) RAM Watchdog Register */
+  __IO uint32_t MCAN_CCCR;    /**< \brief (Mcan Offset: 0x18) CC Control Register */
+  __IO uint32_t MCAN_NBTP;    /**< \brief (Mcan Offset: 0x1C) Nominal Bit Timing and Prescaler Register */
+  __IO uint32_t MCAN_TSCC;    /**< \brief (Mcan Offset: 0x20) Timestamp Counter Configuration Register */
+  __IO uint32_t MCAN_TSCV;    /**< \brief (Mcan Offset: 0x24) Timestamp Counter Value Register */
+  __IO uint32_t MCAN_TOCC;    /**< \brief (Mcan Offset: 0x28) Timeout Counter Configuration Register */
+  __IO uint32_t MCAN_TOCV;    /**< \brief (Mcan Offset: 0x2C) Timeout Counter Value Register */
+  __I  uint32_t Reserved1[4];
+  __I  uint32_t MCAN_ECR;     /**< \brief (Mcan Offset: 0x40) Error Counter Register */
+  __I  uint32_t MCAN_PSR;     /**< \brief (Mcan Offset: 0x44) Protocol Status Register */
+  __IO uint32_t MCAN_TDCR;    /**< \brief (Mcan Offset: 0x48) Transmitter Delay Compensation Register */
+  __I  uint32_t Reserved2[1];
+  __IO uint32_t MCAN_IR;      /**< \brief (Mcan Offset: 0x50) Interrupt Register */
+  __IO uint32_t MCAN_IE;      /**< \brief (Mcan Offset: 0x54) Interrupt Enable Register */
+  __IO uint32_t MCAN_ILS;     /**< \brief (Mcan Offset: 0x58) Interrupt Line Select Register */
+  __IO uint32_t MCAN_ILE;     /**< \brief (Mcan Offset: 0x5C) Interrupt Line Enable Register */
+  __I  uint32_t Reserved3[8];
+  __IO uint32_t MCAN_GFC;     /**< \brief (Mcan Offset: 0x80) Global Filter Configuration Register */
+  __IO uint32_t MCAN_SIDFC;   /**< \brief (Mcan Offset: 0x84) Standard ID Filter Configuration Register */
+  __IO uint32_t MCAN_XIDFC;   /**< \brief (Mcan Offset: 0x88) Extended ID Filter Configuration Register */
+  __I  uint32_t Reserved4[1];
+  __IO uint32_t MCAN_XIDAM;   /**< \brief (Mcan Offset: 0x90) Extended ID AND Mask Register */
+  __I  uint32_t MCAN_HPMS;    /**< \brief (Mcan Offset: 0x94) High Priority Message Status Register */
+  __IO uint32_t MCAN_NDAT1;   /**< \brief (Mcan Offset: 0x98) New Data 1 Register */
+  __IO uint32_t MCAN_NDAT2;   /**< \brief (Mcan Offset: 0x9C) New Data 2 Register */
+  __IO uint32_t MCAN_RXF0C;   /**< \brief (Mcan Offset: 0xA0) Receive FIFO 0 Configuration Register */
+  __I  uint32_t MCAN_RXF0S;   /**< \brief (Mcan Offset: 0xA4) Receive FIFO 0 Status Register */
+  __IO uint32_t MCAN_RXF0A;   /**< \brief (Mcan Offset: 0xA8) Receive FIFO 0 Acknowledge Register */
+  __IO uint32_t MCAN_RXBC;    /**< \brief (Mcan Offset: 0xAC) Receive Rx Buffer Configuration Register */
+  __IO uint32_t MCAN_RXF1C;   /**< \brief (Mcan Offset: 0xB0) Receive FIFO 1 Configuration Register */
+  __I  uint32_t MCAN_RXF1S;   /**< \brief (Mcan Offset: 0xB4) Receive FIFO 1 Status Register */
+  __IO uint32_t MCAN_RXF1A;   /**< \brief (Mcan Offset: 0xB8) Receive FIFO 1 Acknowledge Register */
+  __IO uint32_t MCAN_RXESC;   /**< \brief (Mcan Offset: 0xBC) Receive Buffer / FIFO Element Size Configuration Register */
+  __IO uint32_t MCAN_TXBC;    /**< \brief (Mcan Offset: 0xC0) Transmit Buffer Configuration Register */
+  __I  uint32_t MCAN_TXFQS;   /**< \brief (Mcan Offset: 0xC4) Transmit FIFO/Queue Status Register */
+  __IO uint32_t MCAN_TXESC;   /**< \brief (Mcan Offset: 0xC8) Transmit Buffer Element Size Configuration Register */
+  __I  uint32_t MCAN_TXBRP;   /**< \brief (Mcan Offset: 0xCC) Transmit Buffer Request Pending Register */
+  __IO uint32_t MCAN_TXBAR;   /**< \brief (Mcan Offset: 0xD0) Transmit Buffer Add Request Register */
+  __IO uint32_t MCAN_TXBCR;   /**< \brief (Mcan Offset: 0xD4) Transmit Buffer Cancellation Request Register */
+  __I  uint32_t MCAN_TXBTO;   /**< \brief (Mcan Offset: 0xD8) Transmit Buffer Transmission Occurred Register */
+  __I  uint32_t MCAN_TXBCF;   /**< \brief (Mcan Offset: 0xDC) Transmit Buffer Cancellation Finished Register */
+  __IO uint32_t MCAN_TXBTIE;  /**< \brief (Mcan Offset: 0xE0) Transmit Buffer Transmission Interrupt Enable Register */
+  __IO uint32_t MCAN_TXBCIE;  /**< \brief (Mcan Offset: 0xE4) Transmit Buffer Cancellation Finished Interrupt Enable Register */
+  __I  uint32_t Reserved5[2];
+  __IO uint32_t MCAN_TXEFC;   /**< \brief (Mcan Offset: 0xF0) Transmit Event FIFO Configuration Register */
+  __I  uint32_t MCAN_TXEFS;   /**< \brief (Mcan Offset: 0xF4) Transmit Event FIFO Status Register */
+  __IO uint32_t MCAN_TXEFA;   /**< \brief (Mcan Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
+} Mcan;
+#endif
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 /* -------- MCAN_CREL : (MCAN Offset: 0x00) Core Release Register -------- */
 #define MCAN_CREL_DAY_Pos 0
@@ -112,6 +170,7 @@ typedef struct {
 #define MCAN_CUST_CSV_Pos 0
 #define MCAN_CUST_CSV_Msk (0xffffffffu << MCAN_CUST_CSV_Pos) /**< \brief (MCAN_CUST) Customer-specific Value */
 #define MCAN_CUST_CSV(value) ((MCAN_CUST_CSV_Msk & ((value) << MCAN_CUST_CSV_Pos)))
+#ifdef MRLA
 /* -------- MCAN_FBTP : (MCAN Offset: 0x0C) Fast Bit Timing and Prescaler Register -------- */
 #define MCAN_FBTP_FSJW_Pos 0
 #define MCAN_FBTP_FSJW_Msk (0x3u << MCAN_FBTP_FSJW_Pos) /**< \brief (MCAN_FBTP) Fast (Re) Synchronization Jump Width */
@@ -131,6 +190,24 @@ typedef struct {
 #define MCAN_FBTP_TDCO_Pos 24
 #define MCAN_FBTP_TDCO_Msk (0x1fu << MCAN_FBTP_TDCO_Pos) /**< \brief (MCAN_FBTP) Transceiver Delay Compensation Offset */
 #define MCAN_FBTP_TDCO(value) ((MCAN_FBTP_TDCO_Msk & ((value) << MCAN_FBTP_TDCO_Pos)))
+#else
+/* -------- MCAN_DBTP : (MCAN Offset: 0x0C) Data Bit Timing & Prescaler Register -------- RevB */
+#define MCAN_DBTP_DSJW_Pos 0
+#define MCAN_DBTP_DSJW_Msk (0xfu << MCAN_DBTP_DSJW_Pos) /**< \brief (MCAN_DBTP) (Re) Synchronization Jump Width */
+#define MCAN_DBTP_DSJW(value) ((MCAN_DBTP_DSJW_Msk & ((value) << MCAN_DBTP_DSJW_Pos)))
+#define MCAN_DBTP_DTSEG2_Pos 4
+#define MCAN_DBTP_DTSEG2_Msk (0xfu << MCAN_DBTP_DTSEG2_Pos) /**< \brief (MCAN_DBTP) Time Segment After Sample Point */
+#define MCAN_DBTP_DTSEG2(value) ((MCAN_DBTP_DTSEG2_Msk & ((value) << MCAN_DBTP_DTSEG2_Pos)))
+#define MCAN_DBTP_DTSEG1_Pos 8
+#define MCAN_DBTP_DTSEG1_Msk (0x1fu << MCAN_DBTP_DTSEG1_Pos) /**< \brief (MCAN_DBTP) Time Segment Before Sample Point */
+#define MCAN_DBTP_DTSEG1(value) ((MCAN_DBTP_DTSEG1_Msk & ((value) << MCAN_DBTP_DTSEG1_Pos)))
+#define MCAN_DBTP_DBRP_Pos 16
+#define MCAN_DBTP_DBRP_Msk (0x1fu << MCAN_DBTP_DBRP_Pos) /**< \brief (MCAN_DBTP) Baud Rate Prescaler */
+#define MCAN_DBTP_DBRP(value) ((MCAN_DBTP_DBRP_Msk & ((value) << MCAN_DBTP_DBRP_Pos)))
+#define MCAN_DBTP_TDC (0x1u << 23) /**< \brief (MCAN_DBTP) Transceiver Delay Compensation */
+#define   MCAN_DBTP_TDC_DISABLED (0x0u << 23) /**< \brief (MCAN_DBTP) Transceiver Delay Compensation disabled. */
+#define   MCAN_DBTP_TDC_ENABLED (0x1u << 23) /**< \brief (MCAN_DBTP) Transceiver Delay Compensation enabled. */
+#endif
 /* -------- MCAN_TEST : (MCAN Offset: 0x10) Test Register -------- */
 #define MCAN_TEST_LBCK (0x1u << 4) /**< \brief (MCAN_TEST) Loop Back Mode (read/write) */
 #define   MCAN_TEST_LBCK_DISABLED (0x0u << 4) /**< \brief (MCAN_TEST) Reset value. Loop Back mode is disabled. */
@@ -143,9 +220,11 @@ typedef struct {
 #define   MCAN_TEST_TX_DOMINANT (0x2u << 5) /**< \brief (MCAN_TEST) Dominant ('0') level at pin CANTX. */
 #define   MCAN_TEST_TX_RECESSIVE (0x3u << 5) /**< \brief (MCAN_TEST) Recessive ('1') at pin CANTX. */
 #define MCAN_TEST_RX (0x1u << 7) /**< \brief (MCAN_TEST) Receive Pin (read-only) */
+#ifdef MRLA
 #define MCAN_TEST_TDCV_Pos 8
 #define MCAN_TEST_TDCV_Msk (0x3fu << MCAN_TEST_TDCV_Pos) /**< \brief (MCAN_TEST) Transceiver Delay Compensation Value (read-only) */
 #define MCAN_TEST_TDCV(value) ((MCAN_TEST_TDCV_Msk & ((value) << MCAN_TEST_TDCV_Pos)))
+#endif
 /* -------- MCAN_RWD : (MCAN Offset: 0x14) RAM Watchdog Register -------- */
 #define MCAN_RWD_WDC_Pos 0
 #define MCAN_RWD_WDC_Msk (0xffu << MCAN_RWD_WDC_Pos) /**< \brief (MCAN_RWD) Watchdog Configuration (read/write) */
@@ -176,6 +255,7 @@ typedef struct {
 #define MCAN_CCCR_TEST (0x1u << 7) /**< \brief (MCAN_CCCR) Test Mode Enable (read/write, write protection against '1') */
 #define   MCAN_CCCR_TEST_DISABLED (0x0u << 7) /**< \brief (MCAN_CCCR) Normal operation, MCAN_TEST register holds reset values. */
 #define   MCAN_CCCR_TEST_ENABLED (0x1u << 7) /**< \brief (MCAN_CCCR) Test mode, write access to MCAN_TEST register enabled. */
+#ifdef MRLA
 #define MCAN_CCCR_CME_Pos 8
 #define MCAN_CCCR_CME_Msk (0x3u << MCAN_CCCR_CME_Pos) /**< \brief (MCAN_CCCR) CAN Mode Enable (read/write, write protection) */
 #define MCAN_CCCR_CME(value) ((MCAN_CCCR_CME_Msk & ((value) << MCAN_CCCR_CME_Pos)))
@@ -191,6 +271,15 @@ typedef struct {
 #define MCAN_CCCR_FDO (0x1u << 12) /**< \brief (MCAN_CCCR) CAN FD Operation (read-only) */
 #define MCAN_CCCR_FDBS (0x1u << 13) /**< \brief (MCAN_CCCR) CAN FD Bit Rate Switching (read-only) */
 #define MCAN_CCCR_TXP (0x1u << 14) /**< \brief (MCAN_CCCR) Transmit Pause (read/write, write protection) */
+#else
+#define MCAN_CCCR_FDOE (0x1u << 8) /**< \brief (MCAN_CCCR) FD Operation Enable (read/write, write protection) */
+#define MCAN_CCCR_BRSE (0x1u << 9) /**< \brief (MCAN_CCCR) Bit Rate Switch Enable (read/write, write protection) */
+#define MCAN_CCCR_PXHD (0x1u << 12) /**< \brief (MCAN_CCCR) Protocol Exception Handling disable (read/write, write protection) */
+#define MCAN_CCCR_EFBI (0x1u << 13) /**< \brief (MCAN_CCCR) Edge Filtering during Bus Integration (read/write, write protection) */
+#define MCAN_CCCR_TXP (0x1u << 14) /**< \brief (MCAN_CCCR) Transmit Pause (read/write, write protection) */
+#define MCAN_CCCR_NISO (0x1u << 15) /**< \brief (MCAN_CCCR) Non ISO Operation (read/write, write protection) */
+#endif
+#ifdef MRLA
 /* -------- MCAN_BTP : (MCAN Offset: 0x1C) Bit Timing and Prescaler Register -------- */
 #define MCAN_BTP_SJW_Pos 0
 #define MCAN_BTP_SJW_Msk (0xfu << MCAN_BTP_SJW_Pos) /**< \brief (MCAN_BTP) (Re) Synchronization Jump Width */
@@ -204,6 +293,21 @@ typedef struct {
 #define MCAN_BTP_BRP_Pos 16
 #define MCAN_BTP_BRP_Msk (0x3ffu << MCAN_BTP_BRP_Pos) /**< \brief (MCAN_BTP) Baud Rate Prescaler */
 #define MCAN_BTP_BRP(value) ((MCAN_BTP_BRP_Msk & ((value) << MCAN_BTP_BRP_Pos)))
+#else
+/* -------- MCAN_BTP : (MCAN Offset: 0x1C) Bit Timing and Prescaler Register -------- */
+#define MCAN_NBTP_NTSEG2_Pos 0
+#define MCAN_NBTP_NTSEG2_Msk (0x7Fu << MCAN_NBTP_NTSEG2_Pos) /**< \brief (MCAN_NBTP) Time Segment After Sample Point */
+#define MCAN_NBTP_NTSEG2(value) ((MCAN_NBTP_NTSEG2_Msk & ((value) << MCAN_NBTP_NTSEG2_Pos)))
+#define MCAN_NBTP_NTSEG1_Pos 8
+#define MCAN_NBTP_NTSEG1_Msk (0xFFu << MCAN_NBTP_NTSEG1_Pos) /**< \brief (MCAN_NBTP) Time Segment Before Sample Point */
+#define MCAN_NBTP_NTSEG1(value) ((MCAN_NBTP_NTSEG1_Msk & ((value) << MCAN_NBTP_NTSEG1_Pos)))
+#define MCAN_NBTP_NBRP_Pos 16
+#define MCAN_NBTP_NBRP_Msk (0x1FFu << MCAN_NBTP_NBRP_Pos) /**< \brief (MCAN_NBTP) Baud Rate Prescaler */
+#define MCAN_NBTP_NBRP(value) ((MCAN_NBTP_NBRP_Msk & ((value) << MCAN_NBTP_NBRP_Pos)))
+#define MCAN_NBTP_NSJW_Pos 25
+#define MCAN_NBTP_NSJW_Msk (0x7Fu << MCAN_NBTP_NSJW_Pos) /**< \brief (MCAN_NBTP) (Re) Synchronization Jump Width */
+#define MCAN_NBTP_NSJW(value) ((MCAN_NBTP_NSJW_Msk & ((value) << MCAN_NBTP_NSJW_Pos)))
+#endif
 /* -------- MCAN_TSCC : (MCAN Offset: 0x20) Timestamp Counter Configuration Register -------- */
 #define MCAN_TSCC_TSS_Pos 0
 #define MCAN_TSCC_TSS_Msk (0x3u << MCAN_TSCC_TSS_Pos) /**< \brief (MCAN_TSCC) Timestamp Select */
@@ -264,11 +368,27 @@ typedef struct {
 #define MCAN_PSR_EP (0x1u << 5) /**< \brief (MCAN_PSR) Error Passive */
 #define MCAN_PSR_EW (0x1u << 6) /**< \brief (MCAN_PSR) Warning Status */
 #define MCAN_PSR_BO (0x1u << 7) /**< \brief (MCAN_PSR) Bus_Off Status */
+#ifdef MRLA
 #define MCAN_PSR_FLEC_Pos 8
 #define MCAN_PSR_FLEC_Msk (0x7u << MCAN_PSR_FLEC_Pos) /**< \brief (MCAN_PSR) Fast Last Error Code (set to 111 on read) */
 #define MCAN_PSR_RESI (0x1u << 11) /**< \brief (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) */
 #define MCAN_PSR_RBRS (0x1u << 12) /**< \brief (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) */
 #define MCAN_PSR_REDL (0x1u << 13) /**< \brief (MCAN_PSR) Received a CAN FD Message (cleared on read) */
+#else
+#define MCAN_PSR_RESI (0x1u << 11) /**< \brief (MCAN_PSR) ESI Flag of Last Received CAN FD Message (cleared on read) */
+#define MCAN_PSR_RBRS (0x1u << 12) /**< \brief (MCAN_PSR) BRS Flag of Last Received CAN FD Message (cleared on read) */
+#define MCAN_PSR_REDL (0x1u << 13) /**< \brief (MCAN_PSR) Received a CAN FD Message (cleared on read) */
+#define MCAN_PSR_DLEC_Pos 8
+#define MCAN_PSR_DLEC_Msk (0x7u << MCAN_PSR_DLEC_Pos) /**< \brief (MCAN_PSR) Data Phase Last Error Code (set to 111 on read) */
+#define MCAN_PSR_PXE (0x1u << 14) /**< \brief (MCAN_PSR) Protocol Exception Event (cleared on read) */
+#define MCAN_PSR_TDCV_Pos 16
+#define MCAN_PSR_TDCV_Msk (0x7Fu << MCAN_PSR_TDCV_Pos) /**< \brief (MCAN_PSR) Transmitter Delay Compensation Value (read only) */
+/* -------- MCAN_TDCR : (MCAN Offset: 0x48) Transmitter Delay Compensation Register -------- */
+#define MCAN_TDCR_TDCF_Pos 0
+#define MCAN_TDCR_TDCF_Msk (0x7Fu << MCAN_TDCR_TDCF_Pos)
+#define MCAN_TDCR_TDCO_Pos 8
+#define MCAN_TDCR_TDCO_Msk (0x7Fu << MCAN_TDCR_TDCO_Pos)
+#endif
 /* -------- MCAN_IR : (MCAN Offset: 0x50) Interrupt Register -------- */
 #define MCAN_IR_RF0N (0x1u << 0) /**< \brief (MCAN_IR) Receive FIFO 0 New Message */
 #define MCAN_IR_RF0W (0x1u << 1) /**< \brief (MCAN_IR) Receive FIFO 0 Watermark Reached */
@@ -297,11 +417,17 @@ typedef struct {
 #define MCAN_IR_EW (0x1u << 24) /**< \brief (MCAN_IR) Warning Status */
 #define MCAN_IR_BO (0x1u << 25) /**< \brief (MCAN_IR) Bus_Off Status */
 #define MCAN_IR_WDI (0x1u << 26) /**< \brief (MCAN_IR) Watchdog Interrupt */
+#ifdef MRLA
 #define MCAN_IR_CRCE (0x1u << 27) /**< \brief (MCAN_IR) CRC Error */
 #define MCAN_IR_BE (0x1u << 28) /**< \brief (MCAN_IR) Bit Error */
 #define MCAN_IR_ACKE (0x1u << 29) /**< \brief (MCAN_IR) Acknowledge Error */
 #define MCAN_IR_FOE (0x1u << 30) /**< \brief (MCAN_IR) Format Error */
 #define MCAN_IR_STE (0x1u << 31) /**< \brief (MCAN_IR) Stuff Error */
+#else
+#define MCAN_IR_PEA (0x1u << 27) /**< \brief (MCAN_IR) x */
+#define MCAN_IR_PED (0x1u << 28) /**< \brief (MCAN_IR) x */
+#define MCAN_IR_ARA (0x1u << 29) /**< \brief (MCAN_IR) x */
+#endif
 /* -------- MCAN_IE : (MCAN Offset: 0x54) Interrupt Enable Register -------- */
 #define MCAN_IE_RF0NE (0x1u << 0) /**< \brief (MCAN_IE) Receive FIFO 0 New Message Interrupt Enable */
 #define MCAN_IE_RF0WE (0x1u << 1) /**< \brief (MCAN_IE) Receive FIFO 0 Watermark Reached Interrupt Enable */
@@ -330,11 +456,17 @@ typedef struct {
 #define MCAN_IE_EWE (0x1u << 24) /**< \brief (MCAN_IE) Warning Status Interrupt Enable */
 #define MCAN_IE_BOE (0x1u << 25) /**< \brief (MCAN_IE) Bus_Off Status Interrupt Enable */
 #define MCAN_IE_WDIE (0x1u << 26) /**< \brief (MCAN_IE) Watchdog Interrupt Enable */
+#ifdef MRLA
 #define MCAN_IE_CRCEE (0x1u << 27) /**< \brief (MCAN_IE) CRC Error Interrupt Enable */
 #define MCAN_IE_BEE (0x1u << 28) /**< \brief (MCAN_IE) Bit Error Interrupt Enable */
 #define MCAN_IE_ACKEE (0x1u << 29) /**< \brief (MCAN_IE) Acknowledge Error Interrupt Enable */
 #define MCAN_IE_FOEE (0x1u << 30) /**< \brief (MCAN_IE) Format Error Interrupt Enable */
 #define MCAN_IE_STEE (0x1u << 31) /**< \brief (MCAN_IE) Stuff Error Interrupt Enable */
+#else
+#define MCAN_IE_PEAE (0x1u << 27) /**< \brief (MCAN_IE) x */
+#define MCAN_IE_PEDE (0x1u << 28) /**< \brief (MCAN_IE) x */
+#define MCAN_IE_ARAE (0x1u << 29) /**< \brief (MCAN_IE) x */
+#endif
 /* -------- MCAN_ILS : (MCAN Offset: 0x58) Interrupt Line Select Register -------- */
 #define MCAN_ILS_RF0NL (0x1u << 0) /**< \brief (MCAN_ILS) Receive FIFO 0 New Message Interrupt Line */
 #define MCAN_ILS_RF0WL (0x1u << 1) /**< \brief (MCAN_ILS) Receive FIFO 0 Watermark Reached Interrupt Line */
@@ -363,11 +495,17 @@ typedef struct {
 #define MCAN_ILS_EWL (0x1u << 24) /**< \brief (MCAN_ILS) Warning Status Interrupt Line */
 #define MCAN_ILS_BOL (0x1u << 25) /**< \brief (MCAN_ILS) Bus_Off Status Interrupt Line */
 #define MCAN_ILS_WDIL (0x1u << 26) /**< \brief (MCAN_ILS) Watchdog Interrupt Line */
+#ifdef MRLA
 #define MCAN_ILS_CRCEL (0x1u << 27) /**< \brief (MCAN_ILS) CRC Error Interrupt Line */
 #define MCAN_ILS_BEL (0x1u << 28) /**< \brief (MCAN_ILS) Bit Error Interrupt Line */
 #define MCAN_ILS_ACKEL (0x1u << 29) /**< \brief (MCAN_ILS) Acknowledge Error Interrupt Line */
 #define MCAN_ILS_FOEL (0x1u << 30) /**< \brief (MCAN_ILS) Format Error Interrupt Line */
 #define MCAN_ILS_STEL (0x1u << 31) /**< \brief (MCAN_ILS) Stuff Error Interrupt Line */
+#else
+#define MCAN_ILS_PEA (0x1u << 27) /**< \brief (MCAN_ILS) x */
+#define MCAN_ILS_PED (0x1u << 28) /**< \brief (MCAN_ILS) x */
+#define MCAN_ILS_ARA (0x1u << 29) /**< \brief (MCAN_ILS) x */
+#endif
 /* -------- MCAN_ILE : (MCAN Offset: 0x5C) Interrupt Line Enable Register -------- */
 #define MCAN_ILE_EINT0 (0x1u << 0) /**< \brief (MCAN_ILE) Enable Interrupt Line 0 */
 #define MCAN_ILE_EINT1 (0x1u << 1) /**< \brief (MCAN_ILE) Enable Interrupt Line 1 */

--- a/samv7/libraries/libchip/source/mcan.c
+++ b/samv7/libraries/libchip/source/mcan.c
@@ -51,25 +51,25 @@
 
 #define CAN_CLK_FREQ_HZ               MCAN_PROG_CLK_FREQ_HZ
 
-#define MCAN0_TSEG1                   (MCAN0_PROP_SEG + MCAN0_PHASE_SEG1 - 1)
-#define MCAN0_TSEG2                   (MCAN0_PHASE_SEG2 - 1)
+#define MCAN0_TSEG1                   (MCAN0_PROP_SEG + MCAN0_PHASE_SEG1 - 1u)
+#define MCAN0_TSEG2                   (MCAN0_PHASE_SEG2 - 1u)
 #define MCAN0_BRP                     ((uint32_t) (((float) CAN_CLK_FREQ_HZ / \
-									   ((float)(MCAN0_TSEG1 + MCAN0_TSEG2 + 3) *\
-										(float) MCAN0_BIT_RATE_BPS)) - 1))
-#define MCAN0_SJW                     (MCAN0_SYNC_JUMP - 1)
-#define MCAN0_FTSEG1                  (MCAN0_FAST_PROP_SEG + MCAN0_FAST_PHASE_SEG1 - 1)
-#define MCAN0_FTSEG2                  (MCAN0_FAST_PHASE_SEG2 - 1)
+									   ((float)(MCAN0_TSEG1 + MCAN0_TSEG2 + 3u) *\
+										(float) MCAN0_BIT_RATE_BPS)) - 1u))
+#define MCAN0_SJW                     (MCAN0_SYNC_JUMP - 1u)
+#define MCAN0_FTSEG1                  (MCAN0_FAST_PROP_SEG + MCAN0_FAST_PHASE_SEG1 - 1u)
+#define MCAN0_FTSEG2                  (MCAN0_FAST_PHASE_SEG2 - 1u)
 #define MCAN0_FBRP                    ((uint32_t) (((float) CAN_CLK_FREQ_HZ / \
-									   ((float)(MCAN0_FTSEG1 + MCAN0_FTSEG2 + 3) * \
-										(float) MCAN0_FAST_BIT_RATE_BPS)) - 1))
-#define MCAN0_FSJW                    (MCAN0_FAST_SYNC_JUMP - 1)
+									   ((float)(MCAN0_FTSEG1 + MCAN0_FTSEG2 + 3u) * \
+										(float) MCAN0_FAST_BIT_RATE_BPS)) - 1u))
+#define MCAN0_FSJW                    (MCAN0_FAST_SYNC_JUMP - 1u)
 
 #define MCAN0_STD_FLTS_WRDS           (MCAN0_NMBR_STD_FLTS)
 /* 128 max filters */
-#define MCAN0_EXT_FLTS_WRDS           (MCAN0_NMBR_EXT_FLTS * 2)
+#define MCAN0_EXT_FLTS_WRDS           (MCAN0_NMBR_EXT_FLTS * 2u)
 /* 64 max filters */
 #define MCAN0_RX_FIFO0_WRDS           (MCAN0_NMBR_RX_FIFO0_ELMTS * \
-									   ((MCAN0_RX_FIFO0_ELMT_SZ/4) + 2))
+									   ((MCAN0_RX_FIFO0_ELMT_SZ/4u) + 2u))
 /* 64 elements max */
 #define MCAN0_RX_FIFO1_WRDS           (MCAN0_NMBR_RX_FIFO1_ELMTS *\
 									   ((MCAN0_RX_FIFO1_ELMT_SZ/4) + 2))
@@ -77,48 +77,48 @@
 #define MCAN0_RX_DED_BUFS_WRDS            (MCAN0_NMBR_RX_DED_BUF_ELMTS * \
 		((MCAN0_RX_BUF_ELMT_SZ/4) + 2))
 /* 64 elements max */
-#define MCAN0_TX_EVT_FIFO_WRDS        (MCAN0_NMBR_TX_EVT_FIFO_ELMTS * 2)
+#define MCAN0_TX_EVT_FIFO_WRDS        (MCAN0_NMBR_TX_EVT_FIFO_ELMTS * 2u)
 /* 32 elements max */
 #define MCAN0_TX_DED_BUF_WRDS         (MCAN0_NMBR_TX_DED_BUF_ELMTS * \
-									   ((MCAN0_TX_BUF_ELMT_SZ/4) + 2))
+									   ((MCAN0_TX_BUF_ELMT_SZ/4u) + 2u))
 /* 32 elements max */
 #define MCAN0_TX_FIFO_Q_WRDS          (MCAN0_NMBR_TX_FIFO_Q_ELMTS *\
-									   ((MCAN0_TX_BUF_ELMT_SZ/4) + 2))
+									   ((MCAN0_TX_BUF_ELMT_SZ/4u) + 2u))
 /* 32 elements max */
 
-#define MCAN1_TSEG1                   (MCAN1_PROP_SEG + MCAN1_PHASE_SEG1 - 1)
-#define MCAN1_TSEG2                   (MCAN1_PHASE_SEG2 - 1)
+#define MCAN1_TSEG1                   (MCAN1_PROP_SEG + MCAN1_PHASE_SEG1 - 1u)
+#define MCAN1_TSEG2                   (MCAN1_PHASE_SEG2 - 1u)
 #define MCAN1_BRP                     ((uint32_t) (((float) CAN_CLK_FREQ_HZ / \
-									   ((float)(MCAN1_TSEG1 + MCAN1_TSEG2 + 3) *\
-										(float) MCAN1_BIT_RATE_BPS)) - 1))
-#define MCAN1_SJW                     (MCAN1_SYNC_JUMP - 1)
-#define MCAN1_FTSEG1                  (MCAN1_FAST_PROP_SEG + MCAN1_FAST_PHASE_SEG1 - 1)
-#define MCAN1_FTSEG2                  (MCAN1_FAST_PHASE_SEG2 - 1)
+									   ((float)(MCAN1_TSEG1 + MCAN1_TSEG2 + 3u) *\
+										(float) MCAN1_BIT_RATE_BPS)) - 1u))
+#define MCAN1_SJW                     (MCAN1_SYNC_JUMP - 1u)
+#define MCAN1_FTSEG1                  (MCAN1_FAST_PROP_SEG + MCAN1_FAST_PHASE_SEG1 - 1u)
+#define MCAN1_FTSEG2                  (MCAN1_FAST_PHASE_SEG2 - 1u)
 #define MCAN1_FBRP                    ((uint32_t) (((float) CAN_CLK_FREQ_HZ /\
-									   ((float)(MCAN1_FTSEG1 + MCAN1_FTSEG2 + 3) *\
-										(float) MCAN1_FAST_BIT_RATE_BPS)) - 1))
-#define MCAN1_FSJW                    (MCAN1_FAST_SYNC_JUMP - 1)
+									   ((float)(MCAN1_FTSEG1 + MCAN1_FTSEG2 + 3u) *\
+										(float) MCAN1_FAST_BIT_RATE_BPS)) - 1u))
+#define MCAN1_FSJW                    (MCAN1_FAST_SYNC_JUMP - 1u)
 
 #define MCAN1_STD_FLTS_WRDS           (MCAN1_NMBR_STD_FLTS)
 /* 128 max filters */
-#define MCAN1_EXT_FLTS_WRDS           (MCAN1_NMBR_EXT_FLTS * 2)
+#define MCAN1_EXT_FLTS_WRDS           (MCAN1_NMBR_EXT_FLTS * 2u)
 /* 64 max filters */
 #define MCAN1_RX_FIFO0_WRDS           (MCAN1_NMBR_RX_FIFO0_ELMTS * \
-									   ((MCAN1_RX_FIFO0_ELMT_SZ/4) + 2))
+									   ((MCAN1_RX_FIFO0_ELMT_SZ/4u) + 2u))
 /* 64 elements max */
 #define MCAN1_RX_FIFO1_WRDS           (MCAN1_NMBR_RX_FIFO1_ELMTS *\
-									   ((MCAN1_RX_FIFO1_ELMT_SZ/4) + 2))
+									   ((MCAN1_RX_FIFO1_ELMT_SZ/4u) + 2u))
 /* 64 elements max */
 #define MCAN1_RX_DED_BUFS_WRDS            (MCAN1_NMBR_RX_DED_BUF_ELMTS * \
-		((MCAN1_RX_BUF_ELMT_SZ/4) + 2))
+		((MCAN1_RX_BUF_ELMT_SZ/4u) + 2u))
 /* 64 elements max */
-#define MCAN1_TX_EVT_FIFO_WRDS        (MCAN1_NMBR_TX_EVT_FIFO_ELMTS * 2)
+#define MCAN1_TX_EVT_FIFO_WRDS        (MCAN1_NMBR_TX_EVT_FIFO_ELMTS * 2u)
 /* 32 elements max */
 #define MCAN1_TX_DED_BUF_WRDS         (MCAN1_NMBR_TX_DED_BUF_ELMTS * \
-									   ((MCAN1_TX_BUF_ELMT_SZ/4) + 2))
+									   ((MCAN1_TX_BUF_ELMT_SZ/4u) + 2u))
 /* 32 elements max */
 #define MCAN1_TX_FIFO_Q_WRDS          (MCAN1_NMBR_TX_FIFO_Q_ELMTS * \
-									   ((MCAN1_TX_BUF_ELMT_SZ/4) + 2))
+									   ((MCAN1_TX_BUF_ELMT_SZ/4u) + 2u))
 /* 32 elements max */
 
 /* validate CAN0 entries */
@@ -446,7 +446,7 @@ static uint32_t can1MsgRam[MCAN1_STD_FLTS_WRDS +
 						   MCAN1_TX_DED_BUF_WRDS +
 						   MCAN1_TX_FIFO_Q_WRDS];
 
-static const uint8_t dlcToMsgLength[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64 };
+static const uint8_t dlcToMsgLength[] = { 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 12u, 16u, 20u, 24u, 32u, 48u, 64u };
 
 const MCan_ConfigType mcan0Config = {
 	MCAN0,
@@ -462,13 +462,13 @@ const MCan_ConfigType mcan0Config = {
 	MCAN0_NMBR_TX_EVT_FIFO_ELMTS,
 	MCAN0_NMBR_TX_DED_BUF_ELMTS,
 	MCAN0_NMBR_TX_FIFO_Q_ELMTS,
-	(MCAN0_RX_FIFO0_DATA_SIZE << 29) | ((MCAN0_RX_FIFO0_ELMT_SZ / 4) + 2),
+	(MCAN0_RX_FIFO0_DATA_SIZE << 29u) | ((MCAN0_RX_FIFO0_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN0_RX_FIFO1_DATA_SIZE << 29) | ((MCAN0_RX_FIFO1_ELMT_SZ / 4) + 2),
+	(MCAN0_RX_FIFO1_DATA_SIZE << 29u) | ((MCAN0_RX_FIFO1_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN0_RX_BUF_DATA_SIZE << 29) | ((MCAN0_RX_BUF_ELMT_SZ / 4) + 2),
+	(MCAN0_RX_BUF_DATA_SIZE << 29u) | ((MCAN0_RX_BUF_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN0_TX_BUF_DATA_SIZE << 29) | ((MCAN0_TX_BUF_ELMT_SZ / 4) + 2),
+	(MCAN0_TX_BUF_DATA_SIZE << 29u) | ((MCAN0_TX_BUF_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
 	{
 		&can0MsgRam[0],
@@ -501,13 +501,13 @@ const MCan_ConfigType mcan1Config = {
 	MCAN1_NMBR_TX_EVT_FIFO_ELMTS,
 	MCAN1_NMBR_TX_DED_BUF_ELMTS,
 	MCAN1_NMBR_TX_FIFO_Q_ELMTS,
-	(MCAN1_RX_FIFO0_DATA_SIZE << 29) | ((MCAN1_RX_FIFO0_ELMT_SZ / 4) + 2),
+	(MCAN1_RX_FIFO0_DATA_SIZE << 29u) | ((MCAN1_RX_FIFO0_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN1_RX_FIFO1_DATA_SIZE << 29) | ((MCAN1_RX_FIFO1_ELMT_SZ / 4) + 2),
+	(MCAN1_RX_FIFO1_DATA_SIZE << 29u) | ((MCAN1_RX_FIFO1_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN1_RX_BUF_DATA_SIZE << 29) | ((MCAN1_RX_BUF_ELMT_SZ / 4) + 2),
+	(MCAN1_RX_BUF_DATA_SIZE << 29u) | ((MCAN1_RX_BUF_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
-	(MCAN1_TX_BUF_DATA_SIZE << 29) | ((MCAN1_TX_BUF_ELMT_SZ / 4) + 2),
+	(MCAN1_TX_BUF_DATA_SIZE << 29u) | ((MCAN1_TX_BUF_ELMT_SZ / 4u) + 2u),
 	/* element size in WORDS */
 	{
 		&can1MsgRam[0],
@@ -559,7 +559,7 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 
 	/* Both MCAN controllers use programmable clock 5 to derive bit rate */
 	// select MCK divided by 1 as programmable clock 5 output
-	PMC->PMC_PCK[5] = PMC_PCK_PRES(MCAN_PROG_CLK_PRESCALER - 1) | MCAN_PROG_CLK_SELECT;
+	PMC->PMC_PCK[5] = PMC_PCK_PRES(MCAN_PROG_CLK_PRESCALER - 1u) | MCAN_PROG_CLK_SELECT;
 	PMC->PMC_SCER = PMC_SCER_PCK5;
 
 	if (MCAN0 ==  mcan) {
@@ -567,18 +567,18 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 		// Enable MCAN peripheral clock
 		PMC_EnablePeripheral(ID_MCAN0);
 		// Configure Message RAM Base Address
-		regVal32 = MATRIX->CCFG_CAN0 & 0x000001FF;
+		regVal32 = MATRIX->CCFG_CAN0 & 0x000001FFu;
 		MATRIX->CCFG_CAN0 = regVal32 |
-							((uint32_t) mcanConfig->msgRam.pStdFilts & 0xFFFF0000);
+							((uint32_t) mcanConfig->msgRam.pStdFilts & 0xFFFF0000u);
 		mCanLine0Irq = MCAN0_IRQn;
 	} else if (MCAN1 ==  mcan) {
 		PIO_Configure(pinsMcan1, PIO_LISTSIZE(pinsMcan1));
 		// Enable MCAN peripheral clock
 		PMC_EnablePeripheral(ID_MCAN1);
 		// Configure Message RAM Base Address
-		regVal32 = MATRIX->CCFG_SYSIO & 0x0000FFFF;
+		regVal32 = MATRIX->CCFG_SYSIO & 0x0000FFFFu;
 		MATRIX->CCFG_SYSIO = regVal32 | ((uint32_t) mcanConfig->msgRam.pStdFilts &
-										  0xFFFF0000);
+										  0xFFFF0000u);
 		mCanLine0Irq = MCAN1_IRQn;
 	} else
 		return;
@@ -597,7 +597,7 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 					 | MCAN_GFC_ANFE(2) | MCAN_GFC_ANFS(2);
 
 	// Extended ID Filter AND mask
-	mcan->MCAN_XIDAM = 0x1FFFFFFF;
+	mcan->MCAN_XIDAM = 0x1FFFFFFFu;
 
 	/* Interrupt configuration - leave initialization with all interrupts off */
 	// Disable all interrupts
@@ -608,13 +608,13 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 	// Disable both interrupt LINE 0 & LINE 1
 	mcan->MCAN_ILE = 0x00;
 	// Clear all interrupt flags
-	mcan->MCAN_IR = 0xFFCFFFFF;
+	mcan->MCAN_IR = 0xFFCFFFFFu;
 	/* Enable NVIC - but no interrupts will happen since all sources are
 	    disabled in MCAN_IE */
 	NVIC_ClearPendingIRQ(mCanLine0Irq);
 	NVIC_EnableIRQ(mCanLine0Irq);
-	NVIC_ClearPendingIRQ((IRQn_Type) (mCanLine0Irq + 1));
-	NVIC_EnableIRQ((IRQn_Type) (mCanLine0Irq + 1));
+	NVIC_ClearPendingIRQ((IRQn_Type) (mCanLine0Irq + 1u));
+	NVIC_EnableIRQ((IRQn_Type) (mCanLine0Irq + 1u));
 
 	/* Configure CAN bit timing */
 	mcan->MCAN_NBTP = mcanConfig->bitTiming;
@@ -638,13 +638,13 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 	mcan->MCAN_TXBC = MAILBOX_ADDRESS((uint32_t) mcanConfig->msgRam.pTxDedBuf)
 					  | MCAN_TXBC_NDTB(mcanConfig->nmbrTxDedBufElmts)
 					  | MCAN_TXBC_TFQS(mcanConfig->nmbrTxFifoQElmts);
-	mcan->MCAN_RXESC = ((mcanConfig->rxBufElmtSize >> (29 - MCAN_RXESC_RBDS_Pos)) &
+	mcan->MCAN_RXESC = ((mcanConfig->rxBufElmtSize >> (29u - MCAN_RXESC_RBDS_Pos)) &
 						MCAN_RXESC_RBDS_Msk) |
-					   ((mcanConfig->rxFifo1ElmtSize >> (29 - MCAN_RXESC_F1DS_Pos)) &
+					   ((mcanConfig->rxFifo1ElmtSize >> (29u - MCAN_RXESC_F1DS_Pos)) &
 						MCAN_RXESC_F1DS_Msk) |
-					   ((mcanConfig->rxFifo0ElmtSize >> (29 - MCAN_RXESC_F0DS_Pos)) &
+					   ((mcanConfig->rxFifo0ElmtSize >> (29u - MCAN_RXESC_F0DS_Pos)) &
 						MCAN_RXESC_F0DS_Msk);
-	mcan->MCAN_TXESC = ((mcanConfig->txBufElmtSize >> (29 - MCAN_TXESC_TBDS_Pos)) &
+	mcan->MCAN_TXESC = ((mcanConfig->txBufElmtSize >> (29u - MCAN_TXESC_TBDS_Pos)) &
 						MCAN_TXESC_TBDS_Msk);
 
 	/* Configure Message Filters */
@@ -663,12 +663,12 @@ void MCAN_Init(const MCan_ConfigType *mcanConfig)
 
 	while (cntr > 0) {
 		*pMsgRam = EXT_FILT_EFEC_DISABLE;
-		pMsgRam = pMsgRam + 2;
+		pMsgRam = pMsgRam + 2u;
 		cntr--;
 	}
 
-	mcan->MCAN_NDAT1 = 0xFFFFFFFF;  // clear new (rx) data flags
-	mcan->MCAN_NDAT2 = 0xFFFFFFFF;  // clear new (rx) data flags
+	mcan->MCAN_NDAT1 = 0xFFFFFFFFu;  // clear new (rx) data flags
+	mcan->MCAN_NDAT2 = 0xFFFFFFFFu;  // clear new (rx) data flags
 
 	/**
 	 * FD operation disabled
@@ -724,7 +724,7 @@ void MCAN_InitLoopback(const MCan_ConfigType *mcanConfig)
 	Mcan *mcan = mcanConfig->pMCan;
 
 	mcan->MCAN_CCCR |= MCAN_CCCR_TEST_ENABLED;
-	mcan->MCAN_CCCR |= MCAN_CCCR_MON_ENABLED;  // for internal loop back
+	// mcan->MCAN_CCCR |= MCAN_CCCR_MON_ENABLED;  // for internal loop back
 	mcan->MCAN_TEST |= MCAN_TEST_LBCK_ENABLED;
 }
 
@@ -859,11 +859,11 @@ uint8_t   *MCAN_ConfigTxDedBuffer(const MCan_ConfigType *mcanConfig,
 					 (mcanConfig->txBufElmtSize & ELMT_SIZE_MASK));
 
 		if (idType == CAN_STD_ID)
-			*pThisTxBuf++ = ((id << 18) & (CAN_11_BIT_ID_MASK << 18));
+			*pThisTxBuf++ = ((id << 18u) & (CAN_11_BIT_ID_MASK << 18u));
 		else
 			*pThisTxBuf++ = BUFFER_XTD_MASK | (id & CAN_29_BIT_ID_MASK);
 
-		*pThisTxBuf++ = (uint32_t) dlc << 16;
+		*pThisTxBuf++ = (uint32_t) dlc << 16u;
 		/* enable transmit from buffer to set TC interrupt bit in IR, but
 		interrupt will not happen unless TC interrupt is enabled*/
 		mcan->MCAN_TXBTIE = (1 << buffer);
@@ -887,9 +887,9 @@ void MCAN_SendTxDedBuffer(const MCan_ConfigType *mcanConfig, uint8_t buffer, uin
           {
 		pThisTxBuf = mcanConfig->msgRam.pTxDedBuf + (buffer *
 					 (mcanConfig->txBufElmtSize & ELMT_SIZE_MASK));
-                pThisTxBuf[1] |= (1 << 20) | (1 << 21);
+                pThisTxBuf[1] |= (1u << 20u) | (1u << 21u);
           }
-          mcan->MCAN_TXBAR = (1 << buffer);
+          mcan->MCAN_TXBAR = (1u << buffer);
         }
 }
 
@@ -905,7 +905,7 @@ uint32_t MCAN_AddToTxFifoQ(const MCan_ConfigType *mcanConfig,
 							uint32_t id, MCan_IdType idType, MCan_DlcType dlc, uint8_t *data, uint8_t mode)
 {
 	Mcan *mcan = mcanConfig->pMCan;
-	uint32_t   putIdx = 255;
+	uint32_t   putIdx = 255u;
 	uint32_t *pThisTxBuf = 0;
 	uint8_t   *pTxData;
 	uint8_t    msgLength;
@@ -985,14 +985,14 @@ void MCAN_ConfigRxBufferFilter(const MCan_ConfigType *mcanConfig,
 				&& (id <= CAN_11_BIT_ID_MASK)) {
 				pThisRxFilt = mcanConfig->msgRam.pStdFilts + filter;
 				// 1 word per filter
-				*pThisRxFilt = STD_FILT_SFEC_BUFFER | (id << 16) |
+				*pThisRxFilt = STD_FILT_SFEC_BUFFER | (id << 16u) |
 							   STD_FILT_SFID2_RX_BUFFER | buffer;
 			}
 		} else {
 			// extended ID
 			if ((filter < mcanConfig->nmbrExtFilts) &&
 				(id <= CAN_29_BIT_ID_MASK)) {
-				pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2 * filter);
+				pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2u * filter);
 				// 2 words per filter
 				*pThisRxFilt++ = (uint32_t) EXT_FILT_EFEC_BUFFER | id;
 				*pThisRxFilt = EXT_FILT_EFID2_RX_BUFFER | buffer;
@@ -1024,7 +1024,7 @@ void MCAN_ConfigRxClassicFilter(const MCan_ConfigType *mcanConfig,
 			&& (mask <= CAN_11_BIT_ID_MASK)) {
 			pThisRxFilt = mcanConfig->msgRam.pStdFilts + filter;
 			// 1 word per filter
-			filterTemp = (uint32_t) STD_FILT_SFT_CLASSIC | (id << 16) | mask;
+			filterTemp = (uint32_t) STD_FILT_SFT_CLASSIC | (id << 16u) | mask;
 
 			if (fifo == CAN_FIFO_0)
 				*pThisRxFilt = STD_FILT_SFEC_FIFO0 | filterTemp;
@@ -1036,7 +1036,7 @@ void MCAN_ConfigRxClassicFilter(const MCan_ConfigType *mcanConfig,
 		if ((filter < mcanConfig->nmbrExtFilts)
 			&& (id <= CAN_29_BIT_ID_MASK)
 			&& (mask <= CAN_29_BIT_ID_MASK)) {
-			pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2 * filter);
+			pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2u * filter);
 
 			// 2 words per filter
 			if (fifo == CAN_FIFO_0)
@@ -1059,10 +1059,10 @@ uint8_t MCAN_IsNewDataInRxDedBuffer(const MCan_ConfigType *mcanConfig,
 {
 	Mcan *mcan = mcanConfig->pMCan;
 
-	if (buffer < 32)
-		return (mcan->MCAN_NDAT1 & (1 << buffer));
-	else if (buffer < 64)
-		return (mcan->MCAN_NDAT1 & (1 << (buffer - 32)));
+	if (buffer < 32u)
+		return (mcan->MCAN_NDAT1 & (1u << buffer));
+	else if (buffer < 64u)
+		return (mcan->MCAN_NDAT1 & (1u << (buffer - 32u)));
 	else
 		return 0;
 }
@@ -1093,11 +1093,11 @@ void MCAN_GetRxDedBuffer(const MCan_ConfigType *mcanConfig,
 			pRxMailbox->info.id = tempRy & BUFFER_EXT_ID_MASK;
 		} else {
 			// standard ID
-			pRxMailbox->info.id = (tempRy & BUFFER_STD_ID_MASK) >> 18;
+			pRxMailbox->info.id = (tempRy & BUFFER_STD_ID_MASK) >> 18u;
 		}
 
 		tempRy = *pThisRxBuf++;  // word R1 contains DLC & time stamp
-		dlc = (tempRy & BUFFER_DLC_MASK) >> 16;
+		dlc = (tempRy & BUFFER_DLC_MASK) >> 16u;
 		pRxMailbox->info.length = dlcToMsgLength[dlc];
 		pRxMailbox->info.timestamp = tempRy & BUFFER_RXTS_MASK;
 		// copy the data from the buffer to the mailbox
@@ -1108,10 +1108,10 @@ void MCAN_GetRxDedBuffer(const MCan_ConfigType *mcanConfig,
 
 		/* clear the new data flag for the buffer */
 
-		if (buffer < 32)
-			mcan->MCAN_NDAT1 = (1 << buffer);
+		if (buffer < 32u)
+			mcan->MCAN_NDAT1 = (1u << buffer);
 		else
-			mcan->MCAN_NDAT1 = (1 << (buffer - 32));
+			mcan->MCAN_NDAT1 = (1u << (buffer - 32u));
 
 	}
 }
@@ -1166,11 +1166,11 @@ uint32_t MCAN_GetRxFifoBuffer(const MCan_ConfigType *mcanConfig,
 			pRxMailbox->info.id = tempRy & BUFFER_EXT_ID_MASK;
 		} else {
 			// standard ID
-			pRxMailbox->info.id = (tempRy & BUFFER_STD_ID_MASK) >> 18;
+			pRxMailbox->info.id = (tempRy & BUFFER_STD_ID_MASK) >> 18u;
 		}
 
 		tempRy = *pThisRxBuf++;  // word R1 contains DLC & timestamps
-		dlc = (tempRy & BUFFER_DLC_MASK) >> 16;
+		dlc = (tempRy & BUFFER_DLC_MASK) >> 16u;
 		pRxMailbox->info.length = dlcToMsgLength[dlc];
 		pRxMailbox->info.timestamp = tempRy & BUFFER_RXTS_MASK;
 		/* copy the data from the buffer to the mailbox */
@@ -1199,7 +1199,7 @@ void MCAN_ConfigRxFifoFilter(const MCan_ConfigType *mcanConfig,
     if ((filter < mcanConfig->nmbrStdFilts) && (id <= CAN_11_BIT_ID_MASK) && (mask <= CAN_11_BIT_ID_MASK)) {
       
       pThisRxFilt = mcanConfig->msgRam.pStdFilts + filter;
-      filterTemp = (uint32_t) STD_FILT_SFT_RANGE | (id << 16) | mask;
+      filterTemp = (uint32_t) STD_FILT_SFT_RANGE | (id << 16u) | mask;
 
       if (fifo == CAN_FIFO_0)
         *pThisRxFilt = STD_FILT_SFEC_FIFO0 | filterTemp;
@@ -1210,7 +1210,7 @@ void MCAN_ConfigRxFifoFilter(const MCan_ConfigType *mcanConfig,
   
     if ((filter < mcanConfig->nmbrExtFilts) && (id <= CAN_29_BIT_ID_MASK) && (mask <= CAN_29_BIT_ID_MASK)) {
       
-      pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2 * filter);
+      pThisRxFilt = mcanConfig->msgRam.pExtFilts + (2u * filter);
 
       // 2 words per filter
       if (fifo == CAN_FIFO_0)


### PR DESCRIPTION
Hi Patrice,

here's the driver for the latest MCAN. It's not compatible to previous MCAN, so I'd recommend keeping them in different source files.

Note that I have changed the buffer location to .ram_nocache. It's possible the start address of Tx Event FIFO or TX Buffers is not aligned to 32 byte. Cache operations on the last RX Buffer or first Tx Event FIFO / TX Buffer could cause a memory corruption*. It's required to add empty dummy slots to align the message RAM or put into non-cached memory.

Kind regards,
Dominik

_* It's possible to set Rx Buffers size to zero, then it would apply to Rx FIFO 1 etc. If my description is unclear, please let me know._